### PR TITLE
Add metadata information to file peeking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ servicex.yaml
 
 #Testing 
 samples_structure.txt
-
+tmp_test.py

--- a/servicex_analysis_utils/file_peeking.py
+++ b/servicex_analysis_utils/file_peeking.py
@@ -196,13 +196,13 @@ def print_structure_from_str(
         structure_dict = json.loads(structure_str)
 
         output_lines.append(
-            f"\n---------------------------\n"
+            "\n---------------------------\n"
             f"\U0001f4c1 Sample: {sample_name}\n"
-            f"---------------------------"
+            "---------------------------"
         )
 
         # Get the metadata first
-        output_lines.append(f"\nFile Metadata \u2139\ufe0f :\n")
+        output_lines.append("\nFile Metadata \u2139\ufe0f :\n")
         if "FileMetaData" not in structure_dict:
             output_lines.append("No FileMetaData found in dataset.")
         else:

--- a/servicex_analysis_utils/file_peeking.py
+++ b/servicex_analysis_utils/file_peeking.py
@@ -69,7 +69,7 @@ def run_query(
             if not is_tree(tree):
                 continue
 
-            if tree_name_clean == "Metadata":
+            if tree_name_clean == "MetaData":
                 fm_branches = [
                     b for b in tree.keys() if b.startswith("FileMetaDataAuxDyn.")
                 ]

--- a/tests/data/expected_metadata.txt
+++ b/tests/data/expected_metadata.txt
@@ -13,7 +13,7 @@ File Metadata ℹ️ :
 File structure with branch filter 🌿 '':
 
 
-🌳 Tree: Metadata
+🌳 Tree: MetaData
    ├── Branches:
    │   ├── FileMetaDataAuxDyn.test_100 ; dtype: AsDtype('>i8')
    │   ├── FileMetaDataAuxDyn.test_abc ; dtype: AsStrings()

--- a/tests/data/expected_metadata.txt
+++ b/tests/data/expected_metadata.txt
@@ -1,0 +1,19 @@
+
+---------------------------
+📁 Sample: test_file
+---------------------------
+
+File Metadata ℹ️ :
+
+── test_100: 100
+── test_abc: abc
+
+---------------------------
+
+File structure with branch filter 🌿 '':
+
+
+🌳 Tree: Metadata
+   ├── Branches:
+   │   ├── FileMetaDataAuxDyn.test_100 ; dtype: AsDtype('>i8')
+   │   ├── FileMetaDataAuxDyn.test_abc ; dtype: AsStrings()

--- a/tests/data/expected_structure.txt
+++ b/tests/data/expected_structure.txt
@@ -1,9 +1,16 @@
 
-File structure of all samples with branch filter '':
-
 ---------------------------
 📁 Sample: test_file
 ---------------------------
+
+File Metadata ℹ️ :
+
+No FileMetaData found in dataset.
+
+---------------------------
+
+File structure with branch filter 🌿 '':
+
 
 🌳 Tree: background
    ├── Branches:

--- a/tests/test_file_peeking_metadata.py
+++ b/tests/test_file_peeking_metadata.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pytest
+import uproot
+import json
+import os
+from servicex_analysis_utils import file_peeking
+from pathlib import Path
+
+
+@pytest.fixture
+def build_test_samples(tmp_path):
+
+    test_path = str(tmp_path / "test_metadata.root")
+    # example data for two branches
+    tree_data = {
+        "FileMetaDataAuxDyn.test_100": [100],
+        "FileMetaDataAuxDyn.test_abc": ["abc"],
+    }
+
+    # Create tmp .root files
+    with uproot.create(test_path) as file:
+        file["Metadata"] = tree_data
+
+    return test_path
+
+
+# Test run_query and print_structure_from_str
+def test_metadata_retrieval(build_test_samples, tmp_path, capsys):
+
+    path = build_test_samples
+    query_output = file_peeking.run_query(path)
+    # Check result
+    expected_result = {
+        "FileMetaData": {"test_100": "100", "test_abc": "abc"},
+        "Metadata": {
+            "FileMetaDataAuxDyn.test_100": "AsDtype('>i8')",
+            "FileMetaDataAuxDyn.test_abc": "AsStrings()",
+        },
+    }
+    encoded_result = json.loads(query_output[0])
+
+    assert encoded_result == expected_result
+
+    # Produce servicex.deliver() like dict
+    # i.e {"Sample Name":"Path"}
+    tree_data = {"branch": query_output}
+    with uproot.create(tmp_path / "encoded.root") as file:
+        file["servicex"] = tree_data
+    assert os.path.exists(
+        tmp_path / "encoded.root"
+    ), f"servicex-like test file not found."
+    deliver_dict = {"test_file": [str(tmp_path / "encoded.root")]}
+
+    ## Test str formating
+    output_str = file_peeking.print_structure_from_str(deliver_dict)
+
+    expected_path = Path("tests/data/expected_metadata.txt")
+    expected = expected_path.read_text(encoding="utf-8")
+
+    assert (
+        expected == output_str
+    ), f"Output does not match expected.\n Output: {output_str}"

--- a/tests/test_file_peeking_metadata.py
+++ b/tests/test_file_peeking_metadata.py
@@ -45,7 +45,7 @@ def build_test_samples(tmp_path):
 
     # Create tmp .root files
     with uproot.create(test_path) as file:
-        file["Metadata"] = tree_data
+        file["MetaData"] = tree_data
 
     return test_path
 
@@ -58,7 +58,7 @@ def test_metadata_retrieval(build_test_samples, tmp_path, capsys):
     # Check result
     expected_result = {
         "FileMetaData": {"test_100": "100", "test_abc": "abc"},
-        "Metadata": {
+        "MetaData": {
             "FileMetaDataAuxDyn.test_100": "AsDtype('>i8')",
             "FileMetaDataAuxDyn.test_abc": "AsStrings()",
         },


### PR DESCRIPTION
This PR adds an additional feature to `get_structure()` :

The python function that runs in the backend collects all information metadata branches. 
Any `FileMetaDataAuxDyn.` branch is read with uproot, and the value is saved to json.

The stdout structure format now shows relevant info:

```shell
File Metadata ℹ️ :

── amiTag: e8514_e8528_s4369_s4370_r16083_r15970_p6697
── beamEnergy: 6800000.0
── beamType: collisions
── conditionsTag: OFLCOND-MC23-SDR-RUN3-05-03
── generatorsInfo: Powheg(v.2_r3631)+Pythia8(v.308)+EvtGen(v.2.1.1)
── geometryVersion: ATLAS-R3S-2021-03-02-00
── isDataOverlay: 0
── mcCampaign: mc23e
── mcProcID: 601237.0
── simFlavour: FullG4_QS
``` 

Unit tests were adapted.