### PR TITLE
Fixed issue #21 bad error when no data is present

### DIFF
--- a/servicex_analysis_utils/materialization.py
+++ b/servicex_analysis_utils/materialization.py
@@ -84,10 +84,12 @@ def to_awk(deliver_dict, dask=False, iterator=False, **kwargs):
                     if iterator == True:
                         awk_arrays[sample] = iterators  # return iterators
                     else:
-                        awk_arrays[sample] = ak.concatenate(
-                            list(iterators)
-                        )  # return array
-
+                        arrays = list(iterators)
+                        if arrays:
+                            awk_arrays[sample] = ak.concatenate(arrays)
+                        else:
+                            logging.warning(f"No arrays yielded for sample {sample}. Check file content or TTree name.")
+                            awk_arrays[sample] = None
                 else:
                     # file is parquet
                     awk_arrays[sample] = ak.from_parquet(paths, **kwargs)

--- a/servicex_analysis_utils/materialization.py
+++ b/servicex_analysis_utils/materialization.py
@@ -89,7 +89,7 @@ def to_awk(deliver_dict, dask=False, iterator=False, **kwargs):
                             awk_arrays[sample] = ak.concatenate(arrays)
                         else:
                             raise RuntimeError(
-                               f"No arrays yielded for sample {sample}. Check file content or TTree name."
+                                f"No arrays yielded for sample {sample}. Check file content or TTree name."
                             )
                 else:
                     # file is parquet

--- a/servicex_analysis_utils/materialization.py
+++ b/servicex_analysis_utils/materialization.py
@@ -88,8 +88,9 @@ def to_awk(deliver_dict, dask=False, iterator=False, **kwargs):
                         if arrays:
                             awk_arrays[sample] = ak.concatenate(arrays)
                         else:
-                            logging.warning(f"No arrays yielded for sample {sample}. Check file content or TTree name.")
-                            awk_arrays[sample] = None
+                            raise RuntimeError(
+                               f"No arrays yielded for sample {sample}. Check file content or TTree name."
+                            )
                 else:
                     # file is parquet
                     awk_arrays[sample] = ak.from_parquet(paths, **kwargs)


### PR DESCRIPTION
When there is no data for a root file that does not use iterator it gives a gross error that Is not easy to understand. This way when there is no data in the file it gives error that makes it clear that is the problem.