### PR TITLE
Add workflow to trigger ServiceX website build on push and pull request

### DIFF
--- a/.github/workflows/trigger_website_build.yaml
+++ b/.github/workflows/trigger_website_build.yaml
@@ -1,0 +1,23 @@
+name: Trigger ServiceX Website Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+  pull_request:
+    paths:
+      - "docs/**"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch publishWebsite workflow
+        run: |
+          gh workflow run publishWebsite.yml \
+            --repo ssl-hep/ServiceX_Website \
+            --ref main
+        env:
+          GH_TOKEN: ${{ secrets.SERVICEX_WEBSITE_PAT }}


### PR DESCRIPTION
When we make doc changes to this repo this will run the build on the website automatically. The PAT expires after 1 year.